### PR TITLE
Update bower configuration for clean install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "1.2-1.6",
+    "angular": "1.2 - 1.6",
     "momentjs": "~2.5.x"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,7 @@
   ],
   "description": "An AngularJS module to add Moment.js functionality to Angular.",
   "main": [
-    "angular.js",
-    "moment.js"
+    "angular.js"
   ],
   "keywords": [
     "angularjs",

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2-~1.6",
+    "angular": "1.2-1.6",
     "momentjs": "~2.5.x"
   }
 }


### PR DESCRIPTION
Bower install was failing due to syntax of range for angular version. Changed to equivalent range that means >= 1.2.0 and < 1.7

Also was receiving warning that the main property of bower.json can only have one entry per file type. The bower documentation is unclear about what this main property is used for and it does not seem to impact my install or even the wiredep behavior in my project that includes this module, so I just removed the reference to moment.js. Now bower install no longer complains since there is only one .js file referenced.
